### PR TITLE
adding local run command

### DIFF
--- a/haiku-src/package.json
+++ b/haiku-src/package.json
@@ -9,7 +9,8 @@
         "start": "node index.js",
         "dev": "nodemon",
         "test": "mocha haiku-tests.js --reporter mocha-junit-reporter --reporter-options mochaFile=test-results.xml",
-        "build": "ncc build index.js -o dist"
+        "build": "ncc build index.js -o dist",
+        "serve": "node server.js"
     },
     "dependencies": {
         "ejs": "^3.1.8",


### PR DESCRIPTION
```
node server.js
```

Leaving `npm run dev` as it looks like `nodemon` can be used to recycle the site when files changed - would have to test that in combination. If `nodemon` didn't work then I would suggest replacing `npm run dev` command with this one. 

