### PR TITLE
mississippi eit

### DIFF
--- a/haiku-src/haiku-tests.js
+++ b/haiku-src/haiku-tests.js
@@ -38,7 +38,7 @@ describe('GET /nonexistent', () => {
     request(app)
       .get('/nonexistent')
       .expect('Content-Type', /html/)
-      .expect(400)
+      .expect(404)
       .end((err, res) => {
         if (err) return done(err);
         expect(res.status).to.equal(404);

--- a/haiku-src/haikus.json
+++ b/haiku-src/haikus.json
@@ -1,6 +1,6 @@
 [
     {
-        "text": "rain in tupelo,\ndon't forget an umbrella,\nor it will be gloom",
+        "text": "rain in mississippi,\ndon't forget an umbrella,\nor it will be gloom",
         "image": "puddle_jumper_octodex.jpg"
     },
     {


### PR DESCRIPTION
This pull request includes a minor change to the `haiku-src/haikus.json` file. The change updates the text of a haiku, specifically replacing the word "tupelo" with "mississippi".